### PR TITLE
fix(template): lodash's upper function name

### DIFF
--- a/template/{source}/README.md
+++ b/template/{source}/README.md
@@ -9,4 +9,4 @@
 - github: <%= '\<%= github %\>' %>
 - features: <%= '\<%= features %\>' %>
 - year: <%= '\<%= year %\>' %>
-- upper: <%= '\<%= upper(name) %\>' %><% } %>
+- upper: <%= '\<%= _.toUpper(name) %\>' %><% } %>


### PR DESCRIPTION
`upper` method of lodash is not exists anymore, this pr update template to use  [toUpper](https://lodash.com/docs/4.17.15#toUpper) method instead